### PR TITLE
clock_master (0.1.5): add new APIs to SequencerClient

### DIFF
--- a/quel_clock_master/quel_clock_master/__init__.py
+++ b/quel_clock_master/quel_clock_master/__init__.py
@@ -1,7 +1,7 @@
 from quel_clock_master.qubemasterclient import QuBEMasterClient
 from quel_clock_master.sequencerclient import SequencerClient
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 __all__ = [
     "QuBEMasterClient",

--- a/quel_clock_master/quel_clock_master/simpleudpclient.py
+++ b/quel_clock_master/quel_clock_master/simpleudpclient.py
@@ -33,7 +33,7 @@ class SimpleUdpClient:
 
     def _send_recv_generic(self, port: int, data: bytes) -> Tuple[bytes, Union[Tuple[str, int], None]]:
         if len(data) > self.SEND_MAX_PKTSIZE:
-            raise ValueError(f"too large packget size ({len(data)} > {self.SEND_MAX_PKTSIZE})")
+            raise ValueError(f"too large packet size ({len(data)} > {self.SEND_MAX_PKTSIZE})")
 
         with self._lock:
             self._sock.sendto(data, (self._server_ipaddr, port))

--- a/quel_clock_master/setup.cfg
+++ b/quel_clock_master/setup.cfg
@@ -29,9 +29,9 @@ dev =
 [options.entry_points]
 console_scripts =
     quel_clock_master_resetm=quel_clock_master_consoleapps.apps:reset_master_main
-    quel_clock_master_resett=quel_clock_master_consoleapps.apps:reset_target_main
     quel_clock_master_readm=quel_clock_master_consoleapps.apps:read_master_main
     quel_clock_master_readt=quel_clock_master_consoleapps.apps:read_target_main
     quel_clock_master_clear=quel_clock_master_consoleapps.apps:clear_main
     quel_clock_master_kick=quel_clock_master_consoleapps.apps:kick_main
     quel_clock_master_read=quel_clock_master_consoleapps.apps:read_main
+    quel1_reset_wave_subsystem=quel_clock_master_consoleapps.apps:reset_wave_subsystem_main


### PR DESCRIPTION
- add clear_sequencers()
- add terminate_awgs()
- add clear_and_terminate()
- rename kick_softreset() with reset_wave_subsystem() to avoid confusion.
  - the corresponding CLI command is also renamed.
  - it will be relocated to the right place in near future.