### PR TITLE
ic_config: fix port settings of quel1se-fujitsu11-b in loopback script

### DIFF
--- a/quel_ic_config/src/quel_ic_config_cli/quel1_check_all_internal_loopbacks.py
+++ b/quel_ic_config/src/quel_ic_config_cli/quel1_check_all_internal_loopbacks.py
@@ -289,7 +289,7 @@ GEN_VPORT_SETTINGS_QUEL1SE_FUJITSU11_B: dict[str, dict[str, VportSettingType]] =
             "channel": 0,
         },
         "config": {
-            # "lo_freq": 11.5e9,
+            "lo_freq": 11.5e9,
             "cnco_freq": 1.5e9,
             "fnco_freq": 0.0,
             "fullscale_current": 40000,
@@ -310,7 +310,7 @@ GEN_VPORT_SETTINGS_QUEL1SE_FUJITSU11_B: dict[str, dict[str, VportSettingType]] =
             "channel": 0,
         },
         "config": {
-            "lo_freq": 11.5e9,
+            # "lo_freq": 11.5e9,
             "cnco_freq": 1.5e9,
             "fnco_freq": 0.0,
             "fullscale_current": 40000,


### PR DESCRIPTION
LO settings of Port-10 should've been commented out, but actually of Port-9 was commented out.